### PR TITLE
Add `yarn` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "toml": "^3.0.0",
         "typescript": "^4.8.4",
         "web-vitals": "^2.1.4",
-        "winston": "^3.8.2"
+        "winston": "^3.8.2",
+        "yarn": "^1.22.19"
       },
       "devDependencies": {
         "@types/jest": "^29.2.1",
@@ -20134,6 +20135,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -34691,6 +34705,11 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "toml": "^3.0.0",
     "typescript": "^4.8.4",
     "web-vitals": "^2.1.4",
-    "winston": "^3.8.2"
+    "winston": "^3.8.2",
+    "yarn": "^1.22.19"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11078,6 +11078,11 @@
     "y18n" "^5.0.5"
     "yargs-parser" "^21.0.0"
 
+"yarn@^1.22.19":
+  "integrity" "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
+  "resolved" "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz"
+  "version" "1.22.19"
+
 "yauzl@^2.10.0":
   "integrity" "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="
   "resolved" "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz"


### PR DESCRIPTION
If we don't have `yarn` installed globally, a `npm install` will not be enough to make the TailDatabase to work. We still need to manually install `yarn`.

This PR fix the issue if you don't have `yarn` installed.